### PR TITLE
README.MD for alternative method + elite/max level bonus + value adjustment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 A mod for SPT-AKI, an offline single player emulator for the game Escape from Tarkov.
 
 Adds health to all bodyparts of the players PMC and SCAV characters based on their respective levels.
+
+### Alternative heath boost mode:
+* Head HP modifier to help surviving aimbots (default x 3.0)
+* Staggered health bonus per nth-level:
+  * Every 3 level: Arm HP +3
+  * Every 5 level: Stomach HP +7 and Leg HP +5
+  * Every 7 level: Head HP +5, Thorax HP +7
+* Health skill level bonus is now a multiplier on the Alternative Base Health Preset
+  |       |           |       |       |             |       |       |               |
+  |      -|          -|      -|      -|            -|      -|      -|              -|
+  |       | Alt. Base | Lv.21 | Lv.51 | Lv.99 (+)   | Skill | Elite | ABSOLUTE MAX  |
+  |Thorax |      `90` | `+21` | `+49` | `+100(98)`  | `+60`| `+120`|          `310` |
+  |Head   |      `30` | `+15` | `+35` | `+75(70)`   | `+15(45)`|`+30(90)`|`135(195)`|
+  |Stomach|      `90` | `+28` | `+70` | `+135(133)` | `+37` | `+75` |         `300` |
+  |Arms   |      `60` | `+21` | `+51` | `+100(99)`  | `+22` | `+45` |         `205` |
+  |Legs   |      `75` | `+20` | `+50` | `+100(95)`  | `+30` | `+60` |         `235` |

--- a/config/config.json5
+++ b/config/config.json5
@@ -26,8 +26,8 @@
         },
         levels_per_partial_inc:
         {
-            thorax:  5,
-            stomach: 7,
+            thorax:  7,
+            stomach: 5,
             head:    7,
             l_arm:   3,
             l_leg:   5,
@@ -36,7 +36,7 @@
         },
         partial_inc_per_level:
         {
-            thorax:  5,
+            thorax:  7,
             stomach: 7,
             head:    5,
             l_arm:   3,
@@ -47,13 +47,13 @@
         partial_mul_per_skill:
         {
             // permille
-            thorax: 9,
-            stomach: 5,
-            head: 3,
-            l_arm: 5,
-            l_leg: 7,
-            r_arm: 5,
-            r_leg: 7
+            thorax: 13.37, // 90(base) * 0.01337 * 50 * 2.0(elite) ~= +120
+            stomach: 8.34, // 90(base) * 0.00834 * 50 * 2.0(elite) ~= +75
+            head: 10.0, // 30(base) * 0.01 * 50 * 2.0(elite) = +30 AND * 3.0(head_boost) = +90
+            l_arm: 7.57, // 60(base) * 0.00757 * 50 * 2.0(elite) ~= +45
+            l_leg: 8.0, // 75(base) * 0.008 * 50 * 2.0(elite) = +60
+            r_arm: 7.57,
+            r_leg: 8.0
         }
     },
 

--- a/config/config.json5
+++ b/config/config.json5
@@ -1,8 +1,8 @@
 {
     enabled: true,
-    
+
     // ---If this is false just use the _PMC values for both scav and PMC---
-    split_scav_and_PMC_health : false, 
+    split_scav_and_PMC_health : false,
 
     // These options allow you to decide if you want to keep bleeding and fractures threshold at more or less consistent level
     keep_bleeding_chance_consistant: true,
@@ -10,7 +10,54 @@
 
     show_realism_warning: true,
 
-    PMC: 
+    ALT:
+    {
+        alt_enabled: false,
+        head_boost: 3.0,
+        alt_base_health:
+        {
+            thorax:  90,
+            stomach: 90,
+            head:    30,
+            l_arm:   60,
+            l_leg:   75,
+            r_arm:   60,
+            r_leg:   75
+        },
+        levels_per_partial_inc:
+        {
+            thorax:  5,
+            stomach: 7,
+            head:    7,
+            l_arm:   3,
+            l_leg:   5,
+            r_arm:   3,
+            r_leg:   5
+        },
+        partial_inc_per_level:
+        {
+            thorax:  5,
+            stomach: 7,
+            head:    5,
+            l_arm:   3,
+            l_leg:   5,
+            r_arm:   3,
+            r_leg:   5
+        },
+        partial_mul_per_skill:
+        {
+            // permille
+            thorax: 9,
+            stomach: 5,
+            head: 3,
+            l_arm: 5,
+            l_leg: 7,
+            r_arm: 5,
+            r_leg: 7
+        }
+    },
+
+    PMC:
     {
         // How many levels does the playerPMC have to level up by before the code changes their health values
         levels_per_increment: 5,
@@ -21,7 +68,7 @@
         level_health_skill_cap_value: 25,
 
         // The following lines are for changing the base health values for the playerPMC, the default values are for default EFT
-        base_health: 
+        base_health:
         {
             thorax_base_health: 85,
             stomach_base_health: 70,
@@ -32,7 +79,7 @@
             right_leg_base_health:65
         },
         // The following lines are for changing the amount of health increased per increment for PMC/ALL
-        increase_per_level: 
+        increase_per_level:
         {
             thorax_health_per_level: 2,
             stomach_health_per_level: 2,
@@ -44,7 +91,7 @@
         },
         // The following lines are for changing the amount of health increased per increment of Health skill for PMC/ALL
         health_per_health_skill_level: true,
-        increase_per_health_skill_level: 
+        increase_per_health_skill_level:
         {
             health_skill_thorax_health_per_level: 1,
             health_skill_stomach_health_per_level: 1,
@@ -67,7 +114,7 @@
         level_health_skill_cap_value: 25,
 
         // The following lines are for changing the base health values for the playerscav, the default values are for default EFT
-        base_health: 
+        base_health:
         {
             thorax_base_health: 85,
             stomach_base_health: 70,
@@ -78,7 +125,7 @@
             right_leg_base_health:65
         },
         // The following lines are for changing the amount of health increased per increment for SCAV ONLY
-        increase_per_level: 
+        increase_per_level:
         {
             thorax_health_per_level: 2,
             stomach_health_per_level: 2,

--- a/src/ConfigExports.ts
+++ b/src/ConfigExports.ts
@@ -11,6 +11,14 @@ export interface IHealthPerLevelConfig
     keepBleedingChanceConsistant:boolean;
     increaseThresholdEveryIncrement: boolean;
     showRealismWarning: boolean;
+    ALT: {
+        alt_enabled:boolean;
+        head_boost:number;
+        alt_base_health:{ [key: string]: number };
+        levels_per_partial_inc:{ [key: string]: number };
+        partial_inc_per_level:{ [key: string]: number };
+        partial_mul_per_skill:{ [key: string]: number };
+    }
     PMC: {
         levelsPerIncrement:number;
         levelCap:boolean;
@@ -45,14 +53,14 @@ export interface IHealthPerLevelConfig
     }
 }
 
-export class ConfigExports 
+export class ConfigExports
 {
     private configJson: any;
 
     constructor(container: DependencyContainer)
     {
         const fss = container.resolve<FileSystemSync>("FileSystemSync");
-        this.configJson = json5.parse(fss.read(path.resolve(__dirname, "../config/config.json5")));        
+        this.configJson = json5.parse(fss.read(path.resolve(__dirname, "../config/config.json5")));
     }
 
     public getConfig(): IHealthPerLevelConfig
@@ -62,12 +70,57 @@ export class ConfigExports
 
     private mapConfig()
     {
-        return { 
+        return {
             enabled: this.configJson.enabled,
             splitScavAndPmcHealth: this.configJson.split_scav_and_PMC_health,
             keepBleedingChanceConsistant: this.configJson.keep_bleeding_chance_consistant,
             increaseThresholdEveryIncrement: this.configJson.increase_threshold_every_increment,
             showRealismWarning: this.configJson.show_realism_warning,
+            ALT:
+            {
+                alt_enabled: this.configJson.ALT.alt_enabled,
+                head_boost: this.configJson.ALT.head_boost,
+                alt_base_health:
+                {
+                    Chest: this.configJson.ALT.alt_base_health.thorax,
+                    Stomach: this.configJson.ALT.alt_base_health.stomach,
+                    Head: this.configJson.ALT.alt_base_health.head,
+                    LeftArm: this.configJson.ALT.alt_base_health.l_arm,
+                    LeftLeg: this.configJson.ALT.alt_base_health.l_leg,
+                    RightArm: this.configJson.ALT.alt_base_health.r_arm,
+                    RightLeg: this.configJson.ALT.alt_base_health.r_leg,
+                },
+                levels_per_partial_inc:
+                {
+                    Chest: this.configJson.ALT.levels_per_partial_inc.thorax,
+                    Stomach: this.configJson.ALT.levels_per_partial_inc.stomach,
+                    Head: this.configJson.ALT.levels_per_partial_inc.head,
+                    LeftArm: this.configJson.ALT.levels_per_partial_inc.l_arm,
+                    LeftLeg: this.configJson.ALT.levels_per_partial_inc.l_leg,
+                    RightArm: this.configJson.ALT.levels_per_partial_inc.r_arm,
+                    RightLeg: this.configJson.ALT.levels_per_partial_inc.r_leg,
+                },
+                partial_inc_per_level:
+                {
+                    Chest: this.configJson.ALT.partial_inc_per_level.thorax,
+                    Stomach: this.configJson.ALT.partial_inc_per_level.stomach,
+                    Head: this.configJson.ALT.partial_inc_per_level.head,
+                    LeftArm: this.configJson.ALT.partial_inc_per_level.l_arm,
+                    LeftLeg: this.configJson.ALT.partial_inc_per_level.l_leg,
+                    RightArm: this.configJson.ALT.partial_inc_per_level.r_arm,
+                    RightLeg: this.configJson.ALT.partial_inc_per_level.r_leg,
+                },
+                partial_mul_per_skill:
+                {
+                    Chest: this.configJson.ALT.partial_mul_per_skill.thorax,
+                    Stomach: this.configJson.ALT.partial_mul_per_skill.stomach,
+                    Head: this.configJson.ALT.partial_mul_per_skill.head,
+                    LeftArm: this.configJson.ALT.partial_mul_per_skill.l_arm,
+                    LeftLeg: this.configJson.ALT.partial_mul_per_skill.l_leg,
+                    RightArm: this.configJson.ALT.partial_mul_per_skill.r_arm,
+                    RightLeg: this.configJson.ALT.partial_mul_per_skill.r_leg,
+                }
+            },
             PMC:
             {
                 levelsPerIncrement: this.configJson.PMC.levels_per_increment,
@@ -154,7 +207,7 @@ export class ConfigExports
                     RightLeg: this.configJson.SCAV.increase_per_health_skill_level.health_skill_right_leg_per_level
                 }
             },
-            AI: 
+            AI:
             {
                 enabled: this.configJson.AI.enabled,
                 pmcBotHealth: this.configJson.AI.pmc_bot_health,

--- a/src/HealthPerLevel.ts
+++ b/src/HealthPerLevel.ts
@@ -359,10 +359,14 @@ class HealthPerLevel implements IPreSptLoadMod, IPostDBLoadMod
     postSptLoad(container: DependencyContainer): void
     {
         const presptModLoader = container.resolve<PreSptModLoader>("PreSptModLoader");
+        this.logger = container.resolve<ILogger>("WinstonLogger");
         if (this.cExports.showRealismWarning && presptModLoader.getImportedModsNames().includes("SPT-Realism"))
         {
-            this.logger = container.resolve<ILogger>("WinstonLogger");
             this.logger.logWithColor(this.logPrefix + "REALISM detected, remember to DISABLE Health changes if you want HealthPerLevel to work!", LogTextColor.YELLOW, LogBackgroundColor.RED);
+        }
+        if (presptModLoader.getImportedModsNames().includes("skulltag-personaltrainer")) 
+        {
+            this.logger.logWithColor(this.logPrefix + "Personal Trainer detected, you will encounter errors!", LogTextColor.YELLOW, LogBackgroundColor.RED);
         }
     }
 


### PR DESCRIPTION
### Alternative heath boost mode:
* Head HP modifier to help surviving aimbots (default x 3.0)
* Staggered health bonus per nth-level:
  * Every 3 level: Arm HP +3
  * Every 5 level: Stomach HP +7 and Leg HP +5
  * Every 7 level: Head HP +5, Thorax HP +7
* Health skill level bonus is now a multiplier on the Alternative Base Health Preset
  |       |           |       |       |             |       |       |               |
  |      -|          -|      -|      -|            -|      -|      -|              -|
  |       | Alt. Base | Lv.21 | Lv.51 | Lv.99 (+)   | Skill | Elite | ABSOLUTE MAX  |
  |Thorax |      `90` | `+21` | `+49` | `+100(98)`  | `+60`| `+120`|          `310` |
  |Head   |      `30(90)` | `+15` | `+35` | `+75(70)`   | `+15(45)`|`+30(90)`|`135(255)`|
  |Stomach|      `90` | `+28` | `+70` | `+135(133)` | `+37` | `+75` |         `300` |
  |Arms   |      `60` | `+21` | `+51` | `+100(99)`  | `+22` | `+45` |         `205` |
  |Legs   |      `75` | `+20` | `+50` | `+100(95)`  | `+30` | `+60` |         `235` |